### PR TITLE
use chan struct{} for goroutine controls

### DIFF
--- a/src/scheduler/routines/jobProducer.go
+++ b/src/scheduler/routines/jobProducer.go
@@ -15,7 +15,7 @@ import (
 type JobProducer struct {
 	producer sarama.AsyncProducer
 	wg       sync.WaitGroup
-	stopSig  chan int
+	stopSig  chan struct{}
 }
 
 // NewJobProducer return a new job producer.
@@ -39,7 +39,7 @@ func NewJobProducer(jobs <-chan []models.Job) *JobProducer {
 
 	jp := &JobProducer{
 		producer: producer,
-		stopSig:  make(chan int),
+		stopSig:  make(chan struct{}),
 	}
 
 	go func() {
@@ -94,7 +94,7 @@ func NewJobProducer(jobs <-chan []models.Job) *JobProducer {
 
 // Close the job producer
 func (jp *JobProducer) Close() {
-	jp.stopSig <- 1
+	jp.stopSig <- struct{}{}
 	jp.producer.AsyncClose()
 	jp.wg.Wait()
 }


### PR DESCRIPTION
chan struct{} has the advantage of being a zeroed size structure against a simple chan int.

It's preferable to use them for channel used for concurrent routine controls.